### PR TITLE
fix OR node choice variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.venv
+Makefile
+dsharp
+
+*.dot
+*.nnf
+*.png

--- a/src/src_sharpSAT/MainSolver/DecisionTree.cpp
+++ b/src/src_sharpSAT/MainSolver/DecisionTree.cpp
@@ -723,11 +723,7 @@ void DTNode::genNNF(ostream & out)
 	}
 	else if (DT_OR == type)
 	{
-		//Dimitar Sht. Shterionov: ignoring negative values on OR nodes
-		if (choiceVar > 0)
-			out << "O " << choiceVar << " " << children.size();
-		else
-			out << "O 0 " << children.size();
+		out << "O " << choiceVar << " " << children.size();
 
 		if (2 != children.size())
 			toSTDOUT("Error: Or node with " << children.size() << " children.");

--- a/src/src_sharpSAT/MainSolver/DecisionTree.cpp
+++ b/src/src_sharpSAT/MainSolver/DecisionTree.cpp
@@ -820,6 +820,7 @@ void DTNode::smooth(int &num_nodes, CMainSolver &solver, set<int> &literals)
 					newAnd->addChild(newOr, true);
 					newOr->addChild(solver.get_lit_node_full(var), true);
 					newOr->addChild(solver.get_lit_node_full(-1 * var), true);
+					newOr->choiceVar = (unsigned) var;
 				}
 			}
 			// Record the new values

--- a/src/src_sharpSAT/MainSolver/DecisionTree.h
+++ b/src/src_sharpSAT/MainSolver/DecisionTree.h
@@ -50,7 +50,7 @@ class DTNode
 
 public:
 
-	int choiceVar;
+	unsigned choiceVar;
 	int nnfID;
 
 	bool checked;

--- a/src/src_sharpSAT/MainSolver/InstanceGraph/InstanceGraph.cpp
+++ b/src/src_sharpSAT/MainSolver/InstanceGraph/InstanceGraph.cpp
@@ -944,8 +944,8 @@ bool CInstanceGraph::createfromFile(const char* lpstrFileName)
 	//---  and add the default values for all variables
 	for (unsigned int i = 0; i <= countAllVars(); i++)
 	{
-		varTranslation[(int) i] = (int) i;
-		varUntranslation[(int) i] = (int) i;
+		varTranslation[(int) i] = i;
+		varUntranslation[(int) i] = i;
 	}
 
 	return true;

--- a/src/src_sharpSAT/MainSolver/InstanceGraph/InstanceGraph.h
+++ b/src/src_sharpSAT/MainSolver/InstanceGraph/InstanceGraph.h
@@ -47,9 +47,9 @@ class CInstanceGraph
 	unsigned int numBinClauses;
 	unsigned int numBinCCls;
 
-	vector<int> varTranslation;
-	vector<int> varUntranslation;
-	vector<int> origTranslation;
+	vector<unsigned> varTranslation;
+	vector<unsigned> varUntranslation;
+	vector<unsigned> origTranslation;
 
 protected:
 
@@ -172,17 +172,17 @@ public:
 	CInstanceGraph();
 	~CInstanceGraph();
 
-	const vector<int> & getVarTranslation() const
+	const vector<unsigned> & getVarTranslation() const
 	{
 		return varTranslation;
 	}
 
-	const vector<int> & getVarUnTranslation() const
+	const vector<unsigned> & getVarUnTranslation() const
 	{
 		return varUntranslation;
 	}
 
-	const vector<int> & getOrigTranslation() const
+	const vector<unsigned> & getOrigTranslation() const
 	{
 		return origTranslation;
 	}

--- a/src/src_sharpSAT/MainSolver/MainSolver.cpp
+++ b/src/src_sharpSAT/MainSolver/MainSolver.cpp
@@ -356,7 +356,7 @@ bool CMainSolver::decide()
 	DTNode * leftLit = get_lit_node(theLit.toSignedInt());
 	DTNode * rightLit = get_lit_node(-1 * theLit.toSignedInt());
 
-	newNode->choiceVar = theLit.toSignedInt();
+	newNode->choiceVar = theLit.toVarIdx();
 
 	// Set the parents
 	left->addParent(newNode, true);

--- a/src/src_sharpSAT/MainSolver/MainSolver.cpp
+++ b/src/src_sharpSAT/MainSolver/MainSolver.cpp
@@ -179,6 +179,7 @@ void CMainSolver::solve(const char *lpstrFileName)
 					
 				// Add an arbitrary choice between the two
 				DTNode* newOr = new DTNode(DT_OR, num_Nodes++);
+				newOr->choiceVar = (unsigned) i;
 				decStack.top().getDTNode()->addChild(newOr, true);
 				newOr->addChild(new DTNode(i, true, num_Nodes++), true);
 				newOr->addChild(new DTNode((-1 * i), true, num_Nodes++), true);
@@ -192,6 +193,7 @@ void CMainSolver::solve(const char *lpstrFileName)
 				
 				newOr->addChild(get_lit_node_full(-1 * i), true);
 				newOr->addChild(newAnd, true);
+				newOr->choiceVar = (unsigned) i;
 				
 				newAnd->addChild(new DTNode(i, true, num_Nodes++), true);
 				newAnd->addChild(botNode, true);
@@ -205,6 +207,7 @@ void CMainSolver::solve(const char *lpstrFileName)
 				
 				newOr->addChild(get_lit_node_full(i), true);
 				newOr->addChild(newAnd, true);
+				newOr->choiceVar = (unsigned) i;
 				
 				newAnd->addChild(new DTNode((-1 * i), true, num_Nodes++), true);
 				newAnd->addChild(botNode, true);

--- a/src/src_sharpSAT/MainSolver/MainSolver.h
+++ b/src/src_sharpSAT/MainSolver/MainSolver.h
@@ -432,7 +432,7 @@ public:
                 }
 	}
 
-	void print_translation(const vector<int> trans)
+	void print_translation(const vector<unsigned> trans)
 	{
 		toSTDOUT("Translation:" << endl);
 		for (int i = 0; i < trans.size(); ++i)
@@ -441,7 +441,7 @@ public:
 		}
 	}
     
-	void translateLiterals(const vector<int> varTranslation) {
+	void translateLiterals(const vector<unsigned> varTranslation) {
 		set<int> nodesSeen;
 		queue<DTNode *> openList;
 		openList.push(decStack.top().getDTNode());


### PR DESCRIPTION
* choice variables are variables (unsigned) not literals (signed)
* remove conditional in NNF code that becomes redundant based on the
above
* fix that literals are translated but not choice variables, which could lead to
wrong OR node labeling

fixes #9 