### PR TITLE
Port code to windows + mac

### DIFF
--- a/src/shared/Interface/AnalyzerData.h
+++ b/src/shared/Interface/AnalyzerData.h
@@ -16,7 +16,10 @@
 #include <string.h>
 
 
-using namespace std;
+using std::vector;
+using std::ifstream;
+using std::ofstream;
+using std::endl;
 
 enum DATA_IDX
 {

--- a/src/shared/RealNumberTypes.h
+++ b/src/shared/RealNumberTypes.h
@@ -3,7 +3,6 @@
 
 
 
-using namespace std;
 
 #ifdef GMP_BIGNUM
 #include <gmpxx.h>

--- a/src/shared/SomeTime.h
+++ b/src/shared/SomeTime.h
@@ -4,7 +4,6 @@
 #include<cstdlib>
 #include <sys/time.h> // To seed random generator
 
-using namespace std;
 
 extern bool diffTimes(timeval& ret, const timeval &tLater, const timeval &tEarlier);
 

--- a/src/src_sharpSAT/Basics.cpp
+++ b/src/src_sharpSAT/Basics.cpp
@@ -19,7 +19,7 @@ bool CSolverConf::disableDynamicDecomp = false;
 
 unsigned int CSolverConf::secsTimeBound = 100000;
 
-unsigned int CSolverConf::maxCacheSize = 0;
+size_t CSolverConf::maxCacheSize = 0;
 
 int CSolverConf::nodeCount = 0;
 

--- a/src/src_sharpSAT/Basics.h
+++ b/src/src_sharpSAT/Basics.h
@@ -25,7 +25,7 @@ public:
 
     static unsigned int secsTimeBound;
 
-    static unsigned int maxCacheSize;   // maximum Cache Size in bytes
+    static size_t maxCacheSize;   // maximum Cache Size in bytes
     
     static int nodeCount; // Nodes currently in use
     

--- a/src/src_sharpSAT/Basics.h
+++ b/src/src_sharpSAT/Basics.h
@@ -5,7 +5,7 @@
 #include <cstdlib>
 #include <iostream>
 
-using namespace std;
+
 
 
 #define FULL_DDNNF
@@ -43,14 +43,14 @@ public:
 #ifdef COMPILE_FOR_GUI
 #define toSTDOUT(X)
 #else
-#define toSTDOUT(X)	if(!CSolverConf::quietMode) cout << X;
+#define toSTDOUT(X)	if(!CSolverConf::quietMode) std::cout << X;
 #endif
 
 
 #ifdef COMPILE_FOR_GUI
 #define toERROUT(X)
 #else
-#define toERROUT(X)	if(!CSolverConf::quietMode) cout << X;
+#define toERROUT(X)	if(!CSolverConf::quietMode) std::cout << X;
 #endif
 
 #ifdef DEBUG

--- a/src/src_sharpSAT/Basics.h
+++ b/src/src_sharpSAT/Basics.h
@@ -76,13 +76,16 @@ enum TriValue
     X = 2
 };
 
-enum DT_NodeType
+// Note: do not use full capital for enum values
+// otherwise DT_BOTTOM/DT_TOP/.. collide with windows.h macros.
+// https://google.github.io/styleguide/cppguide.html#Enumerator_Names
+enum class DT_NodeType
 {
-    DT_AND,
-    DT_OR,
-    DT_LIT,
-    DT_TOP,
-    DT_BOTTOM
+    kDTAnd,
+    kDTOr,
+    kDTLit,
+    kDTTop,
+    kDTBottom
 };
 
 

--- a/src/src_sharpSAT/Basics.h
+++ b/src/src_sharpSAT/Basics.h
@@ -54,7 +54,7 @@ public:
 #endif
 
 #ifdef DEBUG
-#define toDEBUGOUT(X) if(!CSolverConf::quietMode) cout << X;
+#define toDEBUGOUT(X) if(!CSolverConf::quietMode) std::cout << X;
 #else
 #define toDEBUGOUT(X)
 #endif

--- a/src/src_sharpSAT/Basics.h
+++ b/src/src_sharpSAT/Basics.h
@@ -79,7 +79,7 @@ enum TriValue
 // Note: do not use full capital for enum values
 // otherwise DT_BOTTOM/DT_TOP/.. collide with windows.h macros.
 // https://google.github.io/styleguide/cppguide.html#Enumerator_Names
-enum class DT_NodeType
+enum DT_NodeType
 {
     kDTAnd,
     kDTOr,

--- a/src/src_sharpSAT/MainSolver/DecisionStack.cpp
+++ b/src/src_sharpSAT/MainSolver/DecisionStack.cpp
@@ -86,9 +86,9 @@ void CDecisionStack::init(unsigned int resSize)
     allComponentsStack.push_back(new CComponentId());
 
     // initialize the stack to contain at least level zero
-    DTNode * dummyLeft = new DTNode(DT_AND, 2);
-    DTNode * dummyRight = new DTNode(DT_AND, 1);
-    dtMain = new DTNode(DT_AND, 0);
+    DTNode * dummyLeft = new DTNode(DT_NodeType::kDTAnd, 2);
+    DTNode * dummyRight = new DTNode(DT_NodeType::kDTAnd, 1);
+    dtMain = new DTNode(DT_NodeType::kDTAnd, 0);
 
     dummyLeft->addParent(dtMain, true);
     dummyRight->addParent(dtMain, true);

--- a/src/src_sharpSAT/MainSolver/DecisionStack.h
+++ b/src/src_sharpSAT/MainSolver/DecisionStack.h
@@ -17,7 +17,6 @@
 
 #include "DecisionTree.h"
 
-using namespace std;
 
 /** \addtogroup Interna*/
 /*@{*/

--- a/src/src_sharpSAT/MainSolver/DecisionTree.cpp
+++ b/src/src_sharpSAT/MainSolver/DecisionTree.cpp
@@ -92,34 +92,34 @@ int DTNode::getVal()
 
 bool DTNode::isBottom()
 {
-	return type == DT_BOTTOM;
+	return type == DT_NodeType::kDTBottom;
 }
 
 bool DTNode::isTop()
 {
-	return type == DT_TOP;
+	return type == DT_NodeType::kDTTop;
 }
 
 bool DTNode::isValid()
 {
-	return ((type == DT_TOP) || (type == DT_BOTTOM) || (type == DT_LIT)
-			|| (type == DT_AND) || (type == DT_OR));
+	return ((type == DT_NodeType::kDTTop) || (type == DT_NodeType::kDTBottom) || (type == DT_NodeType::kDTLit)
+            || (type == DT_NodeType::kDTAnd) || (type == DT_NodeType::kDTOr));
 }
 
 void DTNode::topIfy()
 {
-	if (DT_LIT == type)
-		toSTDOUT("Warning: Converting DT_LIT to DT_TOP!!" << endl);
+	if (DT_NodeType::kDTLit == type)
+		toSTDOUT("Warning: Converting kDTLit to kDTTop!!" << endl);
 
-	type = DT_TOP;
+	type = DT_NodeType::kDTTop;
 }
 
 void DTNode::botIfy()
 {
-	if (DT_LIT == type)
-		toSTDOUT("Warning: Converting DT_LIT to DT_BOTTOM!!" << endl);
+	if (DT_NodeType::kDTLit == type)
+		toSTDOUT("Warning: Converting kDTLit to kDTBottom!!" << endl);
 
-	type = DT_BOTTOM;
+	type = DT_NodeType::kDTBottom;
 }
 
 // Add parent
@@ -201,7 +201,7 @@ void DTNode::compressNode()
 
 	switch (type)
 	{
-	case DT_AND:
+	case DT_NodeType::kDTAnd:
 		// First we recurse
 		for (it = children.begin(); it != children.end(); it++)
 		{
@@ -222,12 +222,12 @@ void DTNode::compressNode()
 			{
 				(*it)->parentDeleted(this);
 
-				if ((0 == (*it)->numParents()) && ((*it)->getType() != DT_LIT))
+				if ((0 == (*it)->numParents()) && ((*it)->getType() != DT_NodeType::kDTLit))
 					delete *it;
 
 			}
 			children.clear();
-			type = DT_TOP;
+			type = DT_NodeType::kDTTop;
 			return;
 		}
 
@@ -252,7 +252,7 @@ void DTNode::compressNode()
 
 					// Get rid of the oldNode if this was the only parent
 					if ((0 == oldNode->numParents()) && (oldNode->getType()
-							!= DT_LIT))
+                                                         != DT_NodeType::kDTLit))
 					{
 						delete oldNode;
 					}
@@ -263,7 +263,7 @@ void DTNode::compressNode()
 		// Now we check if a False child exists (which falsifies this node)
 		for (it = children.begin(); it != children.end(); it++)
 		{
-			if (DT_BOTTOM == (*it)->getType())
+			if (DT_NodeType::kDTBottom == (*it)->getType())
 			{
 				// Remove the children
 				for (it2 = children.begin(); it2 != children.end(); it2++)
@@ -271,12 +271,12 @@ void DTNode::compressNode()
 					(*it2)->parentDeleted(this);
 
 					if ((0 == (*it2)->numParents()) && ((*it2)->getType()
-							!= DT_LIT))
+                                                        != DT_NodeType::kDTLit))
 						delete *it2;
 
 				}
 				children.clear();
-				type = DT_BOTTOM;
+				type = DT_NodeType::kDTBottom;
 				return;
 			}
 		}
@@ -290,8 +290,8 @@ void DTNode::compressNode()
 			{
 				if (0 == (*it)->numChildren())
 				{
-					if ((DT_AND == (*it)->getType()) || (DT_OR
-							== (*it)->getType()))
+					if ((DT_NodeType::kDTAnd == (*it)->getType()) || (DT_NodeType::kDTOr
+                                                                      == (*it)->getType()))
 					{
 						found = true;
 
@@ -299,7 +299,7 @@ void DTNode::compressNode()
 						childDeleted(*it);
 
 						if ((0 == (*it)->numParents()) && ((*it)->getType()
-								!= DT_LIT))
+                                                           != DT_NodeType::kDTLit))
 							delete *it;
 					}
 				}
@@ -313,7 +313,7 @@ void DTNode::compressNode()
 			found = false;
 			for (it = children.begin(); it != children.end() && !found; it++)
 			{
-				if (DT_TOP == (*it)->getType())
+				if (DT_NodeType::kDTTop == (*it)->getType())
 				{
 					found = true;
 
@@ -321,7 +321,7 @@ void DTNode::compressNode()
 					childDeleted(*it);
 
 					if ((0 == (*it)->numParents()) && ((*it)->getType()
-							!= DT_LIT))
+                                                       != DT_NodeType::kDTLit))
 						delete *it;
 				}
 			}
@@ -334,7 +334,7 @@ void DTNode::compressNode()
 			found = false;
 			for (it = children.begin(); it != children.end() && !found; it++)
 			{
-				if (DT_AND == (*it)->getType())
+				if (DT_NodeType::kDTAnd == (*it)->getType())
 				{
 
 					DTNode * oldNode = (*it);
@@ -355,7 +355,7 @@ void DTNode::compressNode()
 
 					// Remove oldNode if it no longer has a parent
 					if ((0 == oldNode->numParents()) && (oldNode->getType()
-							!= DT_LIT))
+                                                         != DT_NodeType::kDTLit))
 						delete oldNode;
 
 					// Mark as found
@@ -364,7 +364,7 @@ void DTNode::compressNode()
 			}
 		}
 		break;
-	case DT_OR:
+	case DT_NodeType::kDTOr:
 
 		// First we recurse
 		for (it = children.begin(); it != children.end(); it++)
@@ -385,11 +385,11 @@ void DTNode::compressNode()
 			for (it = children.begin(); it != children.end(); it++)
 			{
 				(*it)->parentDeleted(this);
-				if ((0 == (*it)->numParents()) && ((*it)->getType() != DT_LIT))
+				if ((0 == (*it)->numParents()) && ((*it)->getType() != DT_NodeType::kDTLit))
 					delete *it;
 			}
 			children.clear();
-			type = DT_BOTTOM;
+			type = DT_NodeType::kDTBottom;
 			return;
 		}
 
@@ -415,7 +415,7 @@ void DTNode::compressNode()
 
 					// Get rid of the oldNode if this was the only parent
 					if ((0 == oldNode->numParents()) && (oldNode->getType()
-							!= DT_LIT))
+                                                         != DT_NodeType::kDTLit))
 					{
 						delete oldNode;
 					}
@@ -426,18 +426,18 @@ void DTNode::compressNode()
 		// Now we check if a True child exists (which trivializes this node)
 		for (it = children.begin(); it != children.end(); it++)
 		{
-			if (DT_TOP == (*it)->getType())
+			if (DT_NodeType::kDTTop == (*it)->getType())
 			{
 				// Remove the children
 				for (it2 = children.begin(); it2 != children.end(); it2++)
 				{
 					(*it2)->parentDeleted(this);
 					if ((0 == (*it2)->numParents()) && ((*it2)->getType()
-							!= DT_LIT))
+                                                        != DT_NodeType::kDTLit))
 						delete *it2;
 				}
 				children.clear();
-				type = DT_TOP;
+				type = DT_NodeType::kDTTop;
 				return;
 			}
 		}
@@ -451,8 +451,8 @@ void DTNode::compressNode()
 			{
 				if (0 == (*it)->numChildren())
 				{
-					if ((DT_AND == (*it)->getType()) || (DT_OR
-							== (*it)->getType()))
+					if ((DT_NodeType::kDTAnd == (*it)->getType()) || (DT_NodeType::kDTOr
+                                                                      == (*it)->getType()))
 					{
 						found = true;
 
@@ -460,7 +460,7 @@ void DTNode::compressNode()
 						childDeleted(*it);
 
 						if ((0 == (*it)->numParents()) && ((*it)->getType()
-								!= DT_LIT))
+                                                           != DT_NodeType::kDTLit))
 							delete *it;
 					}
 				}
@@ -474,7 +474,7 @@ void DTNode::compressNode()
 			found = false;
 			for (it = children.begin(); it != children.end() && !found; it++)
 			{
-				if (DT_BOTTOM == (*it)->getType())
+				if (DT_NodeType::kDTBottom == (*it)->getType())
 				{
 					found = true;
 
@@ -482,7 +482,7 @@ void DTNode::compressNode()
 					childDeleted(*it);
 
 					if ((0 == (*it)->numParents()) && ((*it)->getType()
-							!= DT_LIT))
+                                                       != DT_NodeType::kDTLit))
 						delete *it;
 				}
 			}
@@ -495,7 +495,7 @@ void DTNode::compressNode()
 			found = false;
 			for (it = children.begin(); it != children.end() && !found; it++)
 			{
-				if (DT_OR == (*it)->getType())
+				if (DT_NodeType::kDTOr == (*it)->getType())
 				{
 					DTNode * oldNode = (*it);
 					oldNode->parentDeleted(this);
@@ -515,7 +515,7 @@ void DTNode::compressNode()
 
 					// Remove oldNode if it no longer has a parent
 					if ((0 == oldNode->numParents()) && (oldNode->getType()
-							!= DT_LIT))
+                                                         != DT_NodeType::kDTLit))
 						delete oldNode;
 
 					// Mark as found
@@ -529,7 +529,7 @@ void DTNode::compressNode()
 			set<int> litChildren;
 			found = false;
 			for (it = children.begin(); it != children.end(); it++) {
-				if (DT_LIT == (*it)->getType()) {
+				if (DT_NodeType::kDTLit == (*it)->getType()) {
 					if (litChildren.find(-1 * (*it)->getVal()) != litChildren.end())
 						found = true;
 					litChildren.insert((*it)->getVal());
@@ -541,9 +541,9 @@ void DTNode::compressNode()
 		}
 		break;
 		/* Leaf node */
-	case DT_BOTTOM:
-	case DT_TOP:
-	case DT_LIT:
+	case DT_NodeType::kDTBottom:
+	case DT_NodeType::kDTTop:
+	case DT_NodeType::kDTLit:
 	default:
 		return;
 	}
@@ -563,7 +563,7 @@ int DTNode::count(bool isRoot)
 	// First we recurse
 	for (it = children.begin(); it != children.end(); it++)
 	{
-		if (DT_LIT == (*it)->getType())
+		if (DT_NodeType::kDTLit == (*it)->getType())
 		{
 			int lit_num = (*it)->getVal();
 			if (litsSeen.find(lit_num) == litsSeen.end())
@@ -658,8 +658,8 @@ void DTNode::reset()
 // Printout
 void DTNode::print(int depth)
 {
-	toSTDOUT("(" << id << "-" << type << ":");
-	if (DT_LIT == type)
+	toSTDOUT("(" << id << "-" << (int) type << ":");
+	if (DT_NodeType::kDTLit == type)
 	{
 		toSTDOUT(val);
 	}
@@ -681,13 +681,13 @@ void DTNode::prepNNF(vector<DTNode*> * nodeList)
 	if (nnfID != -1)
 		return;
 
-	if (((DT_TOP == type) || (DT_BOTTOM == type)) && !(CSolverConf::smoothNNF))
+	if (((DT_NodeType::kDTTop == type) || (DT_NodeType::kDTBottom == type)) && !(CSolverConf::smoothNNF))
 	{
 		toSTDOUT("Error: type of DTNode is either top or bottom." << endl);
 		return;
 	}
 
-	if (DT_LIT != type)
+	if (DT_NodeType::kDTLit != type)
 	{
 		set<DTNode *>::iterator it;
 		for (it = children.begin(); it != children.end(); it++)
@@ -705,13 +705,13 @@ void DTNode::prepNNF(vector<DTNode*> * nodeList)
 // Output the nnf format
 void DTNode::genNNF(ostream & out)
 {
-	if (DT_LIT == type) 
+	if (DT_NodeType::kDTLit == type)
 		out << "L " << val << endl;
-	else if (DT_TOP == type)
+	else if (DT_NodeType::kDTTop == type)
 		out << "A 0" << endl;
-	else if (DT_BOTTOM == type)
+	else if (DT_NodeType::kDTBottom == type)
 		out << "O 0 0" << endl;
-	else if (DT_AND == type)
+	else if (DT_NodeType::kDTAnd == type)
 	{
 		out << "A " << children.size();
 
@@ -721,7 +721,7 @@ void DTNode::genNNF(ostream & out)
 
 		out << endl;
 	}
-	else if (DT_OR == type)
+	else if (DT_NodeType::kDTOr == type)
 	{
 		out << "O " << choiceVar << " " << children.size();
 
@@ -772,7 +772,7 @@ void DTNode::smooth(int &num_nodes, CMainSolver &solver, set<int> &literals)
 	variables.clear();
 
 	// If this is a literal, we just add the variable
-	if (DT_LIT == type) {
+	if (DT_NodeType::kDTLit == type) {
 		int var = (val < 0) ? -1 * val : val;
 		variables.insert(var);
 		literals.insert(val);
@@ -788,7 +788,7 @@ void DTNode::smooth(int &num_nodes, CMainSolver &solver, set<int> &literals)
 	}
 
 	// If this is an AND node, there's nothing to do
-	if (DT_AND == type)
+	if (DT_NodeType::kDTAnd == type)
 		return;
 
 	set<DTNode *> toAdd;
@@ -800,7 +800,7 @@ void DTNode::smooth(int &num_nodes, CMainSolver &solver, set<int> &literals)
 		// If the counts are the same, then it is already smooth
 		if (variables.size() != (*it)->numVariables()) {
 			// Create the new AND child
-			DTNode* newAnd = new DTNode(DT_AND, num_nodes++);
+			DTNode* newAnd = new DTNode(DT_NodeType::kDTAnd, num_nodes++);
 
 			(*it)->parentDeleted(this);
 			
@@ -816,7 +816,7 @@ void DTNode::smooth(int &num_nodes, CMainSolver &solver, set<int> &literals)
 				int var = *var_it;
 				if (!((*it)->hasVariable(var)))
 				{
-					DTNode* newOr = new DTNode(DT_OR, num_nodes++);
+					DTNode* newOr = new DTNode(DT_NodeType::kDTOr, num_nodes++);
 					newAnd->addChild(newOr, true);
 					newOr->addChild(solver.get_lit_node_full(var), true);
 					newOr->addChild(solver.get_lit_node_full(-1 * var), true);

--- a/src/src_sharpSAT/MainSolver/DecisionTree.cpp
+++ b/src/src_sharpSAT/MainSolver/DecisionTree.cpp
@@ -240,9 +240,6 @@ void DTNode::compressNode()
 			{
 				if (1 == (*it)->numChildren())
 				{
-					// Mark as found
-					found = true;
-
 					DTNode * oldNode = (*it);
 
 					childDeleted(oldNode);
@@ -253,9 +250,9 @@ void DTNode::compressNode()
 					// Get rid of the oldNode if this was the only parent
 					if ((0 == oldNode->numParents()) && (oldNode->getType()
                                                          != DT_NodeType::kDTLit))
-					{
 						delete oldNode;
-					}
+                    found = true;
+                    break; // Note: required to prevent segfault (mac OS)
 				}
 			}
 		}
@@ -293,14 +290,14 @@ void DTNode::compressNode()
 					if ((DT_NodeType::kDTAnd == (*it)->getType()) || (DT_NodeType::kDTOr
                                                                       == (*it)->getType()))
 					{
-						found = true;
-
 						(*it)->parentDeleted(this);
 						childDeleted(*it);
 
 						if ((0 == (*it)->numParents()) && ((*it)->getType()
                                                            != DT_NodeType::kDTLit))
 							delete *it;
+                        found = true;
+                        break; // Note: required to prevent segfault (mac OS)
 					}
 				}
 			}
@@ -315,14 +312,14 @@ void DTNode::compressNode()
 			{
 				if (DT_NodeType::kDTTop == (*it)->getType())
 				{
-					found = true;
-
 					(*it)->parentDeleted(this);
 					childDeleted(*it);
 
 					if ((0 == (*it)->numParents()) && ((*it)->getType()
                                                        != DT_NodeType::kDTLit))
 						delete *it;
+                    found = true;
+                    break; // Note: required to prevent segfault (mac OS)
 				}
 			}
 		}
@@ -360,6 +357,7 @@ void DTNode::compressNode()
 
 					// Mark as found
 					found = true;
+                    break; // Note: required to prevent segfault (mac OS)
 				}
 			}
 		}
@@ -402,10 +400,6 @@ void DTNode::compressNode()
 			{
 				if (1 == (*it)->numChildren())
 				{
-
-					// Mark as found
-					found = true;
-
 					DTNode * oldNode = (*it);
 
 					childDeleted(oldNode);
@@ -416,9 +410,9 @@ void DTNode::compressNode()
 					// Get rid of the oldNode if this was the only parent
 					if ((0 == oldNode->numParents()) && (oldNode->getType()
                                                          != DT_NodeType::kDTLit))
-					{
-						delete oldNode;
-					}
+                        delete oldNode;
+                    found = true;
+                    break; // Note: required to prevent segfault (mac OS)
 				}
 			}
 		}
@@ -454,14 +448,14 @@ void DTNode::compressNode()
 					if ((DT_NodeType::kDTAnd == (*it)->getType()) || (DT_NodeType::kDTOr
                                                                       == (*it)->getType()))
 					{
-						found = true;
-
 						(*it)->parentDeleted(this);
 						childDeleted(*it);
 
 						if ((0 == (*it)->numParents()) && ((*it)->getType()
                                                            != DT_NodeType::kDTLit))
 							delete *it;
+                        found = true;
+                        break; // Note: required to prevent segfault (mac OS)
 					}
 				}
 			}
@@ -476,14 +470,14 @@ void DTNode::compressNode()
 			{
 				if (DT_NodeType::kDTBottom == (*it)->getType())
 				{
-					found = true;
-
 					(*it)->parentDeleted(this);
 					childDeleted(*it);
 
 					if ((0 == (*it)->numParents()) && ((*it)->getType()
                                                        != DT_NodeType::kDTLit))
 						delete *it;
+                    found = true;
+                    break; // Note: required to prevent segfault (mac OS)
 				}
 			}
 		}
@@ -520,6 +514,7 @@ void DTNode::compressNode()
 
 					// Mark as found
 					found = true;
+                    break; // Note: required to prevent segfault (mac OS)
 				}
 			}
 		}

--- a/src/src_sharpSAT/MainSolver/DecisionTree.h
+++ b/src/src_sharpSAT/MainSolver/DecisionTree.h
@@ -33,7 +33,8 @@
 
 #include "../Basics.h"
 
-using namespace std;
+using std::set;
+using std::ostream;
 
 class CMainSolver;
 

--- a/src/src_sharpSAT/MainSolver/DecisionTree.h
+++ b/src/src_sharpSAT/MainSolver/DecisionTree.h
@@ -61,7 +61,7 @@ public:
 
 	// Constructor mainly for leaf nodes
 	DTNode(int literal, bool lit_constructor, int CURRENT_ID) :
-		type(DT_LIT), val(literal), firstNode(NULL), secondNode(NULL)
+            type(DT_NodeType::kDTLit), val(literal), firstNode(NULL), secondNode(NULL)
 	{
 		id = CURRENT_ID;
 		nnfID = -1;
@@ -103,7 +103,7 @@ public:
 			if (0 == (*it)->numParents())
 			{
 				// Protect against deleting a literal
-				if (DT_LIT != (*it)->getType())
+				if (DT_NodeType::kDTLit != (*it)->getType())
 					delete (*it);
 			}
 		}

--- a/src/src_sharpSAT/MainSolver/FormulaCache.h
+++ b/src/src_sharpSAT/MainSolver/FormulaCache.h
@@ -6,7 +6,6 @@
 #include<assert.h>
 #endif
 
-#include <sys/sysinfo.h>
 #include <vector>
 #include <iostream>
 
@@ -20,7 +19,23 @@
 #include "InstanceGraph/ComponentTypes.h"
 #include "DecisionStack.h"
 #include "DecisionTree.h"
-using namespace std;
+
+
+
+// Different requirements for different availableMem
+// implementations - platform depended.
+#ifdef __linux__
+#include <unistd.h>
+#include <sys/sysinfo.h>
+#elif __APPLE__ && __MACH__
+#include <unistd.h>
+#elif _WIN32
+#include <windows.h>
+#endif
+/**
+ * @return Available memory in bytes
+ */
+unsigned long availableMem();
 
 typedef unsigned int CacheEntryId;
 

--- a/src/src_sharpSAT/MainSolver/FormulaCache.h
+++ b/src/src_sharpSAT/MainSolver/FormulaCache.h
@@ -28,8 +28,7 @@
 #include <unistd.h>
 #include <sys/sysinfo.h>
 #elif __APPLE__ && __MACH__
-#include <sys/types.h>
-#include <sys/sysctl.h>
+#include <mach/mach_host.h>
 #elif _WIN32
 #include <windows.h>
 #elif HAVE_UNISTD_H && defined _SC_AVPHYS_PAGES && defined _SC_PAGESIZE

--- a/src/src_sharpSAT/MainSolver/FormulaCache.h
+++ b/src/src_sharpSAT/MainSolver/FormulaCache.h
@@ -28,14 +28,17 @@
 #include <unistd.h>
 #include <sys/sysinfo.h>
 #elif __APPLE__ && __MACH__
-#include <unistd.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
 #elif _WIN32
 #include <windows.h>
+#elif HAVE_UNISTD_H && defined _SC_AVPHYS_PAGES && defined _SC_PAGESIZE
+#include <unistd.h>
 #endif
 /**
  * @return Available memory in bytes
  */
-unsigned long availableMem();
+size_t availableMem();
 
 typedef unsigned int CacheEntryId;
 
@@ -210,7 +213,7 @@ class CFormulaCache
     unsigned int lastDivTime;
 
     /*end statistics */
-    unsigned int memUsage;
+    size_t memUsage;
     //unsigned int maxMemUsage;
 
     double avgCachedSize()

--- a/src/src_sharpSAT/MainSolver/InstanceGraph/AtomsAndNodes.h
+++ b/src/src_sharpSAT/MainSolver/InstanceGraph/AtomsAndNodes.h
@@ -10,7 +10,7 @@
 #include "../../Basics.h"
 #include <SomeTime.h>
 
-using namespace std;
+using std::vector;
 
 #define INVALID_DL -1
 

--- a/src/src_sharpSAT/MainSolver/InstanceGraph/ComponentTypes.h
+++ b/src/src_sharpSAT/MainSolver/InstanceGraph/ComponentTypes.h
@@ -324,8 +324,8 @@ template <class _T, unsigned int _bitsPerBlock>
 bool CPackedCompId<_T,_bitsPerBlock>::equals(const CComponentId &rComp) const
 {
 
-    if ( (theVars.capacity() !=  (uint) rComp.countVars()*bpeVars/_bitsPerBlock +1)
-            || theClauses.capacity() != (uint) rComp.countCls()*bpeCls/_bitsPerBlock +1) return false;
+    if ( (theVars.capacity() !=  (unsigned int) rComp.countVars()*bpeVars/_bitsPerBlock +1)
+            || theClauses.capacity() != (unsigned int) rComp.countCls()*bpeCls/_bitsPerBlock +1) return false;
 
     unsigned int bitpos = 0;
     unsigned int h = 0;

--- a/src/src_sharpSAT/MainSolver/InstanceGraph/ComponentTypes.h
+++ b/src/src_sharpSAT/MainSolver/InstanceGraph/ComponentTypes.h
@@ -13,7 +13,6 @@
 
 #include "AtomsAndNodes.h"
 
-using namespace std;
 
 //
 //  the identifier of the components

--- a/src/src_sharpSAT/MainSolver/InstanceGraph/InstanceGraph.cpp
+++ b/src/src_sharpSAT/MainSolver/InstanceGraph/InstanceGraph.cpp
@@ -5,6 +5,9 @@
 #include<limits>
 #include<sstream>
 
+using std::ios;
+using std::string;
+
 CRunAnalyzer theRunAn;
 
 // class constructor
@@ -682,13 +685,13 @@ bool CInstanceGraph::createfromFile(const char* lpstrFileName)
             if (clauseLen > 0)
                 litVec.push_back(0);
             clauseLen = 0;
-            inFile.ignore(numeric_limits<streamsize>::max(), '\n'); // skip till next line
+            inFile.ignore(std::numeric_limits<std::streamsize>::max(), '\n'); // skip till next line
             nLine++;
         }
         else if (!isspace(firstChar)) // if whitespace, we eat it instead
         {
             // no digit (or whitespace) so we skip the line
-            inFile.ignore(numeric_limits<streamsize>::max(),'\n');
+            inFile.ignore(std::numeric_limits<std::streamsize>::max(),'\n');
             nLine++;
         }
     }

--- a/src/src_sharpSAT/MainSolver/InstanceGraph/InstanceGraph.h
+++ b/src/src_sharpSAT/MainSolver/InstanceGraph/InstanceGraph.h
@@ -8,7 +8,6 @@
 #include <assert.h>
 #endif
 
-using namespace std;
 
 #include <Interface/AnalyzerData.h>
 

--- a/src/src_sharpSAT/MainSolver/MainSolver.cpp
+++ b/src/src_sharpSAT/MainSolver/MainSolver.cpp
@@ -165,11 +165,11 @@ void CMainSolver::solve(const char *lpstrFileName)
 			return;
 		
 		// TODO: Fix an AND node to the top
-		if (DT_AND != decStack.top().getDTNode()->getType())
+		if (DT_NodeType::kDTAnd != decStack.top().getDTNode()->getType())
 			toSTDOUT("Error: The top node wasn't an AND node.");
 		
 		// Make sure that every literal appears some place
-		DTNode* botNode = new DTNode(DT_AND, num_Nodes++);
+		DTNode* botNode = new DTNode(DT_NodeType::kDTAnd, num_Nodes++);
 		botNode->botIfy();
 		for (int i = 1; i <= originalVarCount; ++i) {
 		
@@ -178,7 +178,7 @@ void CMainSolver::solve(const char *lpstrFileName)
 				(literals.find(-1 * i) == literals.end())) {
 					
 				// Add an arbitrary choice between the two
-				DTNode* newOr = new DTNode(DT_OR, num_Nodes++);
+				DTNode* newOr = new DTNode(DT_NodeType::kDTOr, num_Nodes++);
 				newOr->choiceVar = (unsigned) i;
 				decStack.top().getDTNode()->addChild(newOr, true);
 				newOr->addChild(new DTNode(i, true, num_Nodes++), true);
@@ -186,8 +186,8 @@ void CMainSolver::solve(const char *lpstrFileName)
 				
 			} else if ((literals.find(i) == literals.end()) && CSolverConf::ensureAllLits) {
 				
-				DTNode* newOr = new DTNode(DT_OR, num_Nodes++);
-				DTNode* newAnd = new DTNode(DT_AND, num_Nodes++);
+				DTNode* newOr = new DTNode(DT_NodeType::kDTOr, num_Nodes++);
+				DTNode* newAnd = new DTNode(DT_NodeType::kDTAnd, num_Nodes++);
 				
 				get_lit_node_full(-1 * i)->sub_parents(newOr);
 				
@@ -200,8 +200,8 @@ void CMainSolver::solve(const char *lpstrFileName)
 				
 			} else if ((literals.find(-1 * i) == literals.end()) && CSolverConf::ensureAllLits) {
 				
-				DTNode* newOr = new DTNode(DT_OR, num_Nodes++);
-				DTNode* newAnd = new DTNode(DT_AND, num_Nodes++);
+				DTNode* newOr = new DTNode(DT_NodeType::kDTOr, num_Nodes++);
+				DTNode* newAnd = new DTNode(DT_NodeType::kDTAnd, num_Nodes++);
 				
 				get_lit_node_full(i)->sub_parents(newOr);
 				
@@ -353,9 +353,9 @@ bool CMainSolver::decide()
 	/////////////////////////////
 
 	// Create the nodes
-	DTNode * newNode = new DTNode(DT_OR, num_Nodes++);
-	DTNode * left = new DTNode(DT_AND, num_Nodes++);
-	DTNode * right = new DTNode(DT_AND, num_Nodes++);
+	DTNode * newNode = new DTNode(DT_NodeType::kDTOr, num_Nodes++);
+	DTNode * left = new DTNode(DT_NodeType::kDTAnd, num_Nodes++);
+	DTNode * right = new DTNode(DT_NodeType::kDTAnd, num_Nodes++);
 	DTNode * leftLit = get_lit_node(theLit.toSignedInt());
 	DTNode * rightLit = get_lit_node(-1 * theLit.toSignedInt());
 
@@ -514,7 +514,7 @@ retStateT CMainSolver::resolveConflict()
 	int backtrackDecLev;
 
 	// Since we have a conflict, we should add a bottom to the current DTNode
-	DTNode * newBot = new DTNode(DT_BOTTOM, num_Nodes++);
+	DTNode * newBot = new DTNode(DT_NodeType::kDTBottom, num_Nodes++);
 	newBot->addParent(decStack.top().getCurrentDTNode(), true);
 
 	for (vector<LiteralIdT>::iterator it = theUnitClauses.begin(); it
@@ -552,7 +552,7 @@ retStateT CMainSolver::resolveConflict()
 				removeAllCachePollutions();
 				decStack.pop();
 
-				newBot = new DTNode(DT_BOTTOM, num_Nodes++);
+				newBot = new DTNode(DT_NodeType::kDTBottom, num_Nodes++);
 				newBot->addParent(decStack.top().getCurrentDTNode(), true);
 
 			}

--- a/src/src_sharpSAT/MainSolver/MainSolver.cpp
+++ b/src/src_sharpSAT/MainSolver/MainSolver.cpp
@@ -136,14 +136,14 @@ void CMainSolver::solve(const char *lpstrFileName)
 
 	// We compress the tree now that the search is finished
 	decStack.top().getDTNode()->uncheck(2);
-	cout << "Uncompressed Edges: " << decStack.top().getDTNode()->count(true) << endl;
+	std::cout << "Uncompressed Edges: " << decStack.top().getDTNode()->count(true) << endl;
 
 	decStack.top().getDTNode()->uncheck(3);
 	decStack.top().getDTNode()->compressNode();
 
 	decStack.top().getDTNode()->uncheck(4);
 	bdg_edge_count = decStack.top().getDTNode()->count(true);
-	cout << "Compressed Edges: " << bdg_edge_count << endl;
+	std::cout << "Compressed Edges: " << bdg_edge_count << endl;
 	
 	// There may have been some translation done during the file parsing
 	//  phase, so we translate the bdg literals back.

--- a/src/src_sharpSAT/MainSolver/MainSolver.h
+++ b/src/src_sharpSAT/MainSolver/MainSolver.h
@@ -19,6 +19,10 @@
  * sollten.
  */
 
+using std::pair;
+using std::vector;
+using std::queue;
+
 /*@{*/
 
 typedef unsigned char viewStateT;

--- a/src/src_sharpSAT/MainSolver/MainSolver.h
+++ b/src/src_sharpSAT/MainSolver/MainSolver.h
@@ -93,7 +93,7 @@ class CMainSolver: public CInstanceGraph
 		decStack.top().includeSol(rnCodedSols);
 		theRunAn.addValue(SOLUTION, decStack.getDL());
 
-		DTNode * newTop = new DTNode(DT_TOP, num_Nodes++);
+		DTNode * newTop = new DTNode(DT_NodeType::kDTTop, num_Nodes++);
 		newTop->addParent(decStack.top().getCurrentDTNode());
 
 	}
@@ -309,7 +309,7 @@ public:
 
 			int node_id = node->getID();
 
-			if (DT_LIT == node->getType())
+			if (DT_NodeType::kDTLit == node->getType())
 			{
 				node_id = get_lit_node(node->getVal())->getID();
 			}
@@ -339,19 +339,19 @@ public:
 				out << " [label=\"";
 				switch (node->getType())
 				{
-				case DT_AND:
+				case DT_NodeType::kDTAnd:
 					out << "AND";
 					break;
-				case DT_OR:
+				case DT_NodeType::kDTOr:
 					out << "OR " << node->choiceVar;
 					break;
-				case DT_BOTTOM:
+				case DT_NodeType::kDTBottom:
 					out << "F";
 					break;
-				case DT_TOP:
+				case DT_NodeType::kDTTop:
 					out << "T";
 					break;
-				case DT_LIT:
+				case DT_NodeType::kDTLit:
 					out << node->getVal();
 					break;
 				default:
@@ -389,7 +389,7 @@ public:
 				{
 					int node_id = (*it)->getID();
 
-					if (DT_LIT == (*it)->getType())
+					if (DT_NodeType::kDTLit == (*it)->getType())
 					{
 						node_id = get_lit_node((*it)->getVal())->getID();
 					}
@@ -487,7 +487,7 @@ public:
 				}
 
 				// process the node
-				if (DT_LIT == node->getType())
+				if (DT_NodeType::kDTLit == node->getType())
 				{
 					if (node->getVal() < 0)
 					{
@@ -499,7 +499,7 @@ public:
 					}
 				}
 
-				if (DT_OR == node->getType())
+				if (DT_NodeType::kDTOr == node->getType())
 				{
 					if (node->choiceVar) {
 						node->choiceVar = varTranslation[node->choiceVar];

--- a/src/src_sharpSAT/main.cpp
+++ b/src/src_sharpSAT/main.cpp
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
 				toSTDOUT("wrong parameters"<<endl);
 				return -1;
 			}
-			CSolverConf::maxCacheSize = atoi(argv[i + 1]) * 1024 * 1024;
+			CSolverConf::maxCacheSize = ((size_t) atoi(argv[i + 1])) * 1024 * 1024;
 			//cout <<"maxCacheSize:" <<CSolverConf::maxCacheSize<<"bytes\n";
 		}
 		else


### PR DESCRIPTION
### Changes
- Extended platform-depended availableMem() with implementation for Windows and Mac (cf. src/src_sharpSAT/MainSolver/FormulaCache.cpp). Required some annoying changes, e.g.:
    * DT_AND conflicted with a macro in windows.h so I changed it to lowercase and pre-pended 'k', following some stylistic Google guideline.
    * using namespace std is not recommended in .h files, and was also causing some conflicts with 'set' from std.
    * uint to unsigned int
    
- Fixed segmentation fault issue on Mac (not sure why it (only) occurred there).
- Changed datatype of some memory related variables into `size_t` to support +4GB cache size. For example, before this pull request, -cs 6000 caused `CSolverConf::maxCacheSize` to overflow.

### Note
Some files appear as entirely changed because they were using CRLF (Windows) as line endings instead of LF (Linux, Mac) and my editor/git converted them. E.g. in SomeTime.h only `using namespace std;` was removed. I can elaborate on changes if needed.

### Verified output
None of the changes should have affected the produced results (model count, nnf, ...). Regardless, I tested on the two files in exp-testing and the statistics (incl. model count) remain the same.


